### PR TITLE
CAP-536

### DIFF
--- a/hived/log.py
+++ b/hived/log.py
@@ -1,5 +1,5 @@
 import logging
-
+from traceback import format_exception
 import simplejson as json
 
 from hived import trail
@@ -26,5 +26,16 @@ class JsonFormatter(logging.Formatter):
         record_dict['_name'] = record.name
         if trail.get_id():
             record_dict['_trail_id'] = trail.get_id()
+
+        if record.exc_info:
+            etype, exc, tb = record.exc_info
+            record_dict['error'] = {
+                'etype': etype.__name__,
+                'exc': exc,
+                'locals': {k: repr(v)
+                           for k, v in tb.tb_frame.f_locals.iteritems()
+                           if not k.startswith('__')},
+                'traceback': format_exception(etype, exc, tb),
+            }
 
         return json.dumps(record_dict, default=json_handler)

--- a/hived/queue.py
+++ b/hived/queue.py
@@ -95,12 +95,12 @@ class ExternalQueue(object):
 
         try:
             return getattr(self.channel, method)(**kwargs)
-        except (AMQPError, IOError) as e:
+        except (AMQPError, IOError):
             if _tries < MAX_TRIES:
                 self._connect()
                 return self._try(method, _tries + 1, **kwargs)
             else:
-                raise ConnectionError(e)
+                raise
 
     def _subscribe(self):
         self.default_queue_name = '%s_%s' % (self.subscription, uuid.uuid4())

--- a/hived/queue.py
+++ b/hived/queue.py
@@ -144,6 +144,7 @@ class ExternalQueue(object):
         return self._try('basic_publish',
                          msg=message,
                          exchange=exchange,
+                         mandatory=True,
                          routing_key=routing_key)
 
     def _parse_message(self, message):

--- a/hived/queue.py
+++ b/hived/queue.py
@@ -117,7 +117,8 @@ class ExternalQueue(object):
         self.subscription = routing_key
         self._connect()
 
-    def put(self, message_dict=None, routing_key='', exchange=None, body=None, priority=0):
+    def put(self, message_dict=None, routing_key='', exchange=None, body=None,
+            priority=0, mandatory=False):
         """
         Publishes a message to the queue.
         message_dict: the json-serializable object that will be published
@@ -144,7 +145,7 @@ class ExternalQueue(object):
         return self._try('basic_publish',
                          msg=message,
                          exchange=exchange,
-                         mandatory=True,
+                         mandatory=mandatory,
                          routing_key=routing_key)
 
     def _parse_message(self, message):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -65,7 +65,7 @@ class ExternalQueueTest(unittest.TestCase):
         self.assertEqual(rv, 'rv')
 
     def test__try_doesnt_try_more_than_max_tries(self):
-        self.channel_mock.method.side_effect = [AMQPError, AMQPError, AMQPError, 'rv']
+        self.channel_mock.method.side_effect = [AMQPError, AMQPError, AMQPError]
         self.assertRaises(AMQPError, self.external_queue._try, 'method')
 
     def test_put_uses_default_exchange_if_not_supplied(self):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import json
 import unittest
 
-from amqp import Message, AMQPError, ConnectionError
+from amqp import Message, AMQPError, ConnectionError, Connection
 from mock import MagicMock, patch, call, Mock, ANY
 
 from hived.queue import (ExternalQueue, MAX_TRIES, SerializationError,
@@ -27,12 +27,13 @@ class ExternalQueueTest(unittest.TestCase):
 
         self.channel_mock = MagicMock()
         self.channel_mock.basic_get.return_value = self.message
+        self.channel_mock.basic_publish.return_value = None
 
         self.connection = MagicMock()
         self.connection.channel.return_value = self.channel_mock
 
         self.connection_cls_patcher = patch('amqp.Connection',
-                                                 return_value=self.connection)
+                                            return_value=self.connection)
         self.connection_cls_mock = self.connection_cls_patcher.start()
 
         self.external_queue = ExternalQueue('localhost', 'username', 'pwd',
@@ -74,6 +75,7 @@ class ExternalQueueTest(unittest.TestCase):
         self.assertEqual(self.channel_mock.basic_publish.call_args_list,
                          [call(msg=amqp_msg,
                                exchange='default_exchange',
+                               mandatory=True,
                                routing_key='')])
 
     def test_add_trail_keys(self):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -75,7 +75,7 @@ class ExternalQueueTest(unittest.TestCase):
         self.assertEqual(self.channel_mock.basic_publish.call_args_list,
                          [call(msg=amqp_msg,
                                exchange='default_exchange',
-                               mandatory=True,
+                               mandatory=False,
                                routing_key='')])
 
     def test_add_trail_keys(self):

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -66,7 +66,7 @@ class ExternalQueueTest(unittest.TestCase):
 
     def test__try_doesnt_try_more_than_max_tries(self):
         self.channel_mock.method.side_effect = [AMQPError, AMQPError, AMQPError, 'rv']
-        self.assertRaises(ConnectionError, self.external_queue._try, 'method')
+        self.assertRaises(AMQPError, self.external_queue._try, 'method')
 
     def test_put_uses_default_exchange_if_not_supplied(self):
         amqp_msg = Message('body', delivery_mode=2, content_type='application/json', priority=0)


### PR DESCRIPTION
Habilita a possibilidade de usar a _flag_ `mandatory` no método `basic_publish` (`queue.put()`).